### PR TITLE
Fix splitting on info's assets

### DIFF
--- a/numismatic/cli.py
+++ b/numismatic/cli.py
@@ -89,7 +89,7 @@ def list_all(state, output):
 @pass_state
 def info(state, assets, output):
     "Info about the requested assets"
-    assets = ','.join(assets).split(',')
+    assets = ','.join(assets)
     datafeed = state['datafeed']
     assets_info = datafeed.get_info(assets)
     write(assets_info, output)


### PR DESCRIPTION
Since splitting was introduced in datafeeds.py for get_info, it can be taken out of cli.py, otherwise an error is raised.

After the fix, the following now all produce output successfully.
```
$ coin info

$ coin info -a ETH
$ coin info -a ETH,BTC
$ coin info -a ETC -a BTC

$ export NUMISMATIC_ASSETS='ETC,BTC'
$ coin info
```