### PR TITLE
using one websocket per exchange connection

### DIFF
--- a/numismatic/cli.py
+++ b/numismatic/cli.py
@@ -274,8 +274,10 @@ def run(state, timeout):
         timeout = None
     loop = asyncio.get_event_loop()
     logger.debug('starting ...')
-    tasks = {name:asyncio.Task(sub.listener) for name, sub in
-             state['subscriptions'].items() if sub.listener is not None}
+    # We have one _listener() per client
+    # tasks = {id(sub.client):asyncio.Task(sub.client.listener) 
+    #          for name, sub in state['subscriptions'].items()}
+    tasks = {}
     try:
         if tasks:
             logger.info(f'Running {len(tasks)} tasks ...')
@@ -289,10 +291,10 @@ def run(state, timeout):
         pass
     finally:
         logger.debug('cancelling ...')
-        pending = {name:task for name, task in tasks.items() 
+        pending = {id_:task for id_, task in tasks.items() 
                    if not task.done()}
-        for task_name, task in pending.items():
-            logger.debug(f'cancelling pending {task_name} ...')
+        for id_, task in pending.items():
+            logger.debug(f'cancelling pending {id_} ...')
             task.cancel()
         logger.debug('sleeping ...')
         loop.run_until_complete(asyncio.sleep(1))

--- a/numismatic/feeds/base.py
+++ b/numismatic/feeds/base.py
@@ -11,6 +11,7 @@ import json
 from streamz import Stream
 import attr
 import websockets
+from websockets.client import WebSocketClientProtocol
 
 from ..requesters import Requester
 from ..config import ConfigMixin
@@ -265,7 +266,9 @@ class WebsocketClient(abc.ABC):
             Connects to websocket. Uses a future to ensure that only one
             connection at a time will happen
         '''
-        if self.websocket is None:
+        if self.websocket is None or \
+                isinstance(self.websocket, WebSocketClientProtocol) and \
+                not self.websocket.open:
             logger.info(f'Connecting to {self.websocket_url!r} ...')
             self.websocket = \
                 asyncio.ensure_future(websockets.connect(self.websocket_url))

--- a/numismatic/feeds/base.py
+++ b/numismatic/feeds/base.py
@@ -280,7 +280,6 @@ class WebsocketClient(abc.ABC):
                 asyncio.ensure_future(websockets.connect(self.websocket_url))
         if isinstance(self.websocket, asyncio.Future):
             self.websocket = await self.websocket
-        return self.websocket
 
     # FIXME: Should this not be named subscribe?
     def listen(self, symbol, channel=None):

--- a/numismatic/feeds/base.py
+++ b/numismatic/feeds/base.py
@@ -249,8 +249,7 @@ class WebsocketClient(abc.ABC):
 
     exchange = None
     websocket_url = None
-    _websocket_future = None
-    __listener = None
+    websocket = None
     subscriptions = []
             
     def __attrs_post_init__(self):
@@ -263,13 +262,12 @@ class WebsocketClient(abc.ABC):
         '''
         if websocket_url is None:
             websocket_url = self.websocket_url
-        if self._websocket_future is None:
+        if self.websocket is None:
             logger.info(f'Connecting to {websocket_url!r} ...')
-            self._websocket_future = \
+            self.websocket = \
                 asyncio.ensure_future(websockets.connect(websocket_url))
-        if not self._websocket_future.done():
-            await self._websocket_future
-        self.websocket = self._websocket_future.result()
+        if isinstance(self.websocket, asyncio.Future):
+            self.websocket = await self.websocket
         return self.websocket
 
     # FIXME: Should this not be named subscribe?

--- a/numismatic/feeds/bitfinex.py
+++ b/numismatic/feeds/bitfinex.py
@@ -23,11 +23,13 @@ class BitfinexWebsocketClient(WebsocketClient):
     exchange = 'Bitfinex'
     websocket_url = 'wss://api.bitfinex.com/ws/2'
 
-    async def on_connect(self, ws):
-        packet = await self.websocket.recv()
-        connection_status = json.loads(packet)
-        logger.info(connection_status)
-        return ws
+    @classmethod
+    def handle_connect(cls, msg, subscription):
+        connection_status = msg
+        logger.debug(connection_status)
+        subscription.handlers.remove(cls.handle_connect)
+        logger.info(f'Removed {cls.__name__}.handle_connect()')
+        return STOP_HANDLERS
 
     async def _subscribe(self, subscription):
         await super()._subscribe(subscription)

--- a/numismatic/feeds/gdax.py
+++ b/numismatic/feeds/gdax.py
@@ -28,7 +28,7 @@ class GDAXWebsocketClient(WebsocketClient):
         await super()._subscribe(subscription)
         # install only the subscriptions handler
         subscription.handlers = [self.__handle_subscriptions]
-        channels = ['ticker'] if subscription.channel=='trades' else \
+        channels = ['ticker'] if subscription.channel=='TRADES' else \
             [subscription.channel]
         msg = dict(type='subscribe', product_ids=[subscription.symbol],
                    channels=channels)

--- a/numismatic/feeds/luno.py
+++ b/numismatic/feeds/luno.py
@@ -43,7 +43,9 @@ class LunoWebsocketClient(WebsocketClient):
         config_item_getter('LunoFeed', 'api_key_secret')), repr=False)
 
     def listen(self, symbol, channel=None, websocket_url=None):
-        self.websocket_url = f'{self.websocket_url}/{symbol}'
+        if websocket_url is None:
+            websocket_url = self.websocket_url
+        websocket_url = f'{websocket_url}/{symbol}'
         return super().listen(symbol, channel, websocket_url)
 
     async def _subscribe(self, subscription):

--- a/numismatic/feeds/luno.py
+++ b/numismatic/feeds/luno.py
@@ -42,13 +42,9 @@ class LunoWebsocketClient(WebsocketClient):
     api_key_secret = attr.ib(default=attr.Factory(
         config_item_getter('LunoFeed', 'api_key_secret')), repr=False)
 
-    async def _connect(self, subscription):
-        websocket_url = f'{self.websocket_url}/{subscription.symbol}'
-        logger.info(f'Connecting to {websocket_url!r} ...')
-        self.websocket = await websockets.connect(websocket_url)
-        if hasattr(self, 'on_connect'):
-            await self.on_connect(self.websocket)
-        return self.websocket
+    def listen(self, symbol, channel=None, websocket_url=None):
+        self.websocket_url = f'{self.websocket_url}/{symbol}'
+        return super().listen(symbol, channel, websocket_url)
 
     async def _subscribe(self, subscription):
         await super()._subscribe(subscription)

--- a/numismatic/feeds/poloniex.py
+++ b/numismatic/feeds/poloniex.py
@@ -35,7 +35,7 @@ class PoloniexWebsocketClient(WebsocketClient):
 
         packet = json.dumps(connection_message)
         logger.info(packet)
-        await PoloniexWebsocketClient.websocket.send(packet)
+        await self.websocket.send(packet)
 
         return subscription
 

--- a/numismatic/feeds/poloniex.py
+++ b/numismatic/feeds/poloniex.py
@@ -35,7 +35,7 @@ class PoloniexWebsocketClient(WebsocketClient):
 
         packet = json.dumps(connection_message)
         logger.info(packet)
-        await self.websocket.send(packet)
+        await PoloniexWebsocketClient.websocket.send(packet)
 
         return subscription
 

--- a/numismatic/numismatic.ini
+++ b/numismatic/numismatic.ini
@@ -13,8 +13,6 @@ channels = trades
 [GDAXFeed]
 
 [LunoFeed]
-# api_key_id = ....
-# api_key_secret = ...
 assets = XBT
 currencies = ZAR
 


### PR DESCRIPTION
This will use one websocket per exchange connection. Derived feeds need to be altered to refer to the class's websocket (as opposed to the instance's websocket). This can probably be elegantly changed to by using @property (which would then need no change for derived feeds)

To test that this works, test it on Poloniex by doing the following:
`coin listen -f poloniex -a ETH,XMR -c BTC collect run`
If this is working as per expectation, I will neaten things and put more effort into things.