### PR TITLE
rest request retry upon failure

### DIFF
--- a/numismatic/feeds/base.py
+++ b/numismatic/feeds/base.py
@@ -249,7 +249,12 @@ class RestClient(abc.ABC):
             raise ValueError(f'{attribute.name}: {value}')
 
     def _make_request(self, api_url, params=None, headers=None, raw=False):
-        response = self.requester.get(api_url, params=params, headers=headers)
+        try:
+            response = self.requester.get(api_url, params=params, headers=headers)
+        except Exception as ex:
+            logger.error(ex)
+            logger.error(packet)
+            raise ex
         if not raw:
             data = response.json()
         else:

--- a/numismatic/numismatic.ini
+++ b/numismatic/numismatic.ini
@@ -8,6 +8,7 @@ channels = trades
 retries = 3
 backoff_factor = 0.3
 status_forcelist=500,502,503,504
+timeout=5
 
 [BitfinexFeed]
 

--- a/numismatic/numismatic.ini
+++ b/numismatic/numismatic.ini
@@ -4,6 +4,11 @@ assets = BTC
 currencies = USD
 channels = trades
 
+[REQUESTER]
+retries = 3
+backoff_factor = 0.3
+status_forcelist=500,502,503,504
+
 [BitfinexFeed]
 
 [BraveNewCoinFeed]

--- a/numismatic/requesters.py
+++ b/numismatic/requesters.py
@@ -1,5 +1,7 @@
 import logging
 import requests
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 import time
 from pathlib import Path
 from functools import partial
@@ -9,6 +11,7 @@ import pickle
 
 import attr
 from appdirs import user_cache_dir
+from .config import config_item_getter
 
 
 log = logging.getLogger(__name__)
@@ -20,6 +23,15 @@ LIBRARY_NAME = 'numismatic'
 @attr.s
 class Requester:
     "Basic Requester using requests and blocking calls"
+
+    retries = attr.ib(default=attr.Factory(
+        config_item_getter('REQUESTER', 'retries')))
+    backoff_factor = attr.ib(default=attr.Factory(
+        config_item_getter('REQUESTER', 'backoff_factor')))
+    status_forcelist = attr.ib(default=attr.Factory(
+        config_item_getter('REQUESTER', 'status_forcelist')),
+        convert=lambda val: tuple(map(int, val.split(','))),
+        validator=attr.validators.instance_of(tuple))
 
     @classmethod
     def factory(cls, requester, **kwargs):
@@ -36,7 +48,18 @@ class Requester:
         return subcls(**kwds)
 
     def get(self, url, params=None, headers=None):
-        response = requests.get(url, params=params, headers=headers)
+        session = requests.Session()
+        retry = Retry(
+            total=self.retries,
+            read=self.retries,
+            connect=self.retries,
+            backoff_factor=self.backoff_factor,
+            status_forcelist=self.status_forcelist,
+        )
+        adapter = HTTPAdapter(max_retries=retry)
+        session.mount('http://', adapter)
+        session.mount('https://', adapter)
+        response = session.get(url, params=params, headers=headers)
         return response
 
 

--- a/numismatic/requesters.py
+++ b/numismatic/requesters.py
@@ -25,9 +25,14 @@ class Requester:
     "Basic Requester using requests and blocking calls"
 
     retries = attr.ib(default=attr.Factory(
-        config_item_getter('REQUESTER', 'retries')))
+        config_item_getter('REQUESTER', 'retries')),
+        convert=int)
+    timeout = attr.ib(default=attr.Factory(
+        config_item_getter('REQUESTER', 'timeout')),
+        convert=int)
     backoff_factor = attr.ib(default=attr.Factory(
-        config_item_getter('REQUESTER', 'backoff_factor')))
+        config_item_getter('REQUESTER', 'backoff_factor')),
+        convert=float)
     status_forcelist = attr.ib(default=attr.Factory(
         config_item_getter('REQUESTER', 'status_forcelist')),
         convert=lambda val: tuple(map(int, val.split(','))),
@@ -59,7 +64,7 @@ class Requester:
         adapter = HTTPAdapter(max_retries=retry)
         session.mount('http://', adapter)
         session.mount('https://', adapter)
-        response = session.get(url, params=params, headers=headers)
+        response = session.get(url, params=params, headers=headers, timeout=self.timeout)
         return response
 
 


### PR DESCRIPTION
When a rest request fails, it should be retried again before giving up. This is best practice (and in fact, I implemented this very feature for Microsoft OneNote).

The code below needs to be unit tested to ensure no regressions. However, we have not agreed upon the framework, so I will do it once it is up.

Lastly, I needed to implement this feature because crypto-compare has been giving lots of 503 responses lately. 503 response is temp unavailable, and one should try again in that case.